### PR TITLE
Filter external flow types

### DIFF
--- a/get-untyped.js
+++ b/get-untyped.js
@@ -41,6 +41,7 @@ module.exports = function(amount) {
         .then(fileString => fileString.split('\n'))
         .then(files => files.filter(file => file !== ''))
         .then(files => files.filter(file => file.indexOf('.js') !== -1))
+        .then(files => files.filter(file => file.indexOf('flow-typed/npm') === -1))
         .then(files =>
             files.map(
                 file =>


### PR DESCRIPTION
Hey!

This tool didn't work for me, till I excluded the external flow type definitions.
```
Something went wrong, I am sorry:
wrong format
```

The files inside `flow-typed/npm` are downloaded or created by `flow-typed` and I don't think they need to be checked.